### PR TITLE
Added port environment variable to login-app

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
       - '/src/app/node_modules'
     environment:
     - filePath="http://host.docker.internal:3002/"
+    
     ports: 
       - '3002:3002'
 
@@ -23,6 +24,7 @@ services:
       - '/web/node_modules'
     environment:
     - filePath="http://host.docker.internal:3003/"
+    - PORT=3003
     ports:
     - '3003:3003'
     stdin_open: true


### PR DESCRIPTION
The PORT environment variable changes what port react-app tries to start on by default. It overrides the default behavior of starting on port 3000.